### PR TITLE
Please update to latest version of rpio

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "repository": "robertklep/node-kaku-rpi",
   "dependencies": {
     "debug": "^2.2.0",
-    "rpio": "^0.9.12"
+    "rpio": "^1.3.0"
   }
 }


### PR DESCRIPTION
Thank you for this project!

You are using an outdated version of rpio, which does not compile on newer versions of node. Updating to the latest version seems to work just fine (I could only test the old KaKu protocol though).
