### PR TITLE
Updated dependencies to make it compile on node 22/24

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "repository": "robertklep/node-kaku-rpi",
   "dependencies": {
-    "debug": "^2.2.0",
-    "rpio": "^1.3.0"
+    "debug": "^4.4.1",
+    "rpio": "^2.4.2"
   }
 }


### PR DESCRIPTION
rpio 1.7.1 is not compiling on node 22 and 24. 
The newest version of rpio does work. Please update to this.